### PR TITLE
Implement addAndExpand to vertical and horizontal layout (#86)

### DIFF
--- a/vaadin-ordered-layout-flow-demo/src/main/java/com/vaadin/flow/component/orderedlayout/demo/AbstractLayout.java
+++ b/vaadin-ordered-layout-flow-demo/src/main/java/com/vaadin/flow/component/orderedlayout/demo/AbstractLayout.java
@@ -107,4 +107,18 @@ public abstract class AbstractLayout extends DemoView {
 
         return new Div(contentBox, borderBox);
     }
+
+    protected Div createLoremIpsum() {
+        Div component = new Div();
+        component.setText("Lorem ipsum dolor sit amet, consectetur " +
+                "adipiscing elit, sed do eiusmod tempor incididunt " +
+                "ut labore et dolore magna aliqua. Ut enim ad minim " +
+                "veniam, quis nostrud exercitation ullamco laboris " +
+                "nisi ut aliquip ex ea commodo consequat. Duis aute " +
+                "irure dolor in reprehenderit in voluptate velit " +
+                "esse cillum dolore eu fugiat nulla pariatur.");
+        component.getStyle().set("border", "1px solid #CCCCCC");
+
+        return component;
+    }
 }

--- a/vaadin-ordered-layout-flow-demo/src/main/java/com/vaadin/flow/component/orderedlayout/demo/OrderedLayoutView.java
+++ b/vaadin-ordered-layout-flow-demo/src/main/java/com/vaadin/flow/component/orderedlayout/demo/OrderedLayoutView.java
@@ -44,6 +44,7 @@ public class OrderedLayoutView extends AbstractLayout {
         createHorizontalLayoutWithExpandRatios();
         createHorizontalLayoutWithCenterComponent();
         createHorizontalLayoutWithBoxSizing();
+        createHorizontalLayoutWithExpandingContent();
 
         createDefaultVerticalLayout();
         createVerticalLayoutWithJustifyContent();
@@ -52,6 +53,7 @@ public class OrderedLayoutView extends AbstractLayout {
         createVerticalLayoutWithExpandRatios();
         createVerticalLayoutWithCenterComponent();
         createVerticalLayoutWithBoxSizing();
+        createVerticalLayoutWithExpandingContent();
     }
 
     /* HorizontalLayout demos */
@@ -280,6 +282,24 @@ public class OrderedLayoutView extends AbstractLayout {
                 layout, createBoxSizingButtons(layout, layout.getId().get()));
     }
 
+    private void createHorizontalLayoutWithExpandingContent() {
+        // begin-source-example
+        // source-example-heading: Horizontal layout with expanding content
+        HorizontalLayout layout = new HorizontalLayout();
+        layout.getStyle().set("border", "1px solid #9E9E9E");
+
+        Div component1 = createLoremIpsum();
+        Div component2 = createLoremIpsum();
+        Div component3 = createLoremIpsum();
+
+        layout.addAndExpand(component1, component2, component3);
+        // end-source-example
+
+        layout.setId("horizontal-layout-with-expanding-content");
+
+        addCard("HorizontalLayout", "Horizontal layout with expanding content", layout);
+    }
+
     /* VerticalLayout demos */
 
     private void createDefaultVerticalLayout() {
@@ -502,6 +522,24 @@ public class OrderedLayoutView extends AbstractLayout {
 
         addCard("VerticalLayout", "VerticalLayout with box-sizing settings",
                 layout, createBoxSizingButtons(layout, layout.getId().get()));
+    }
+
+    private void createVerticalLayoutWithExpandingContent() {
+        // begin-source-example
+        // source-example-heading: Vertical layout with expanding content
+        VerticalLayout layout = new VerticalLayout();
+        layout.getStyle().set("border", "1px solid #9E9E9E");
+
+        Div component1 = createLoremIpsum();
+        Div component2 = createLoremIpsum();
+        Div component3 = createLoremIpsum();
+
+        layout.addAndExpand(component1, component2, component3);
+        // end-source-example
+
+        layout.setId("vertical-layout-with-expanding-content");
+
+        addCard("VerticalLayout", "Vertical layout with expanding content", layout);
     }
 
     /* Override setParameter to redirect to horizontal tab */

--- a/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
+++ b/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/HorizontalLayout.java
@@ -208,4 +208,19 @@ public class HorizontalLayout extends Component
         // that should be used and has better javadocs.
         return FlexComponent.super.getAlignSelf(container);
     }
+
+    /**
+     * Adds the given components to this layout and sets them as expanded. The
+     * flex-grow of all added child components are set to 1 so that the
+     * expansion will be effective. The width of this layout is also set to
+     * 100%.
+     *
+     * @param components
+     *            the components to set, not <code>null</code>
+     */
+    public void addAndExpand(Component... components) {
+        add(components);
+        setWidthFull();
+        expand(components);
+    }
 }

--- a/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/VerticalLayout.java
+++ b/vaadin-ordered-layout-flow/src/main/java/com/vaadin/flow/component/orderedlayout/VerticalLayout.java
@@ -218,4 +218,19 @@ public class VerticalLayout extends Component
         // that should be used and has better javadocs.
         return FlexComponent.super.getAlignSelf(container);
     }
+
+    /**
+     * Adds the given components to this layout and sets them as expanded. The
+     * flex-grow of all added child components are set to 1 so that the
+     * expansion will be effective. The height of this layout is also set to
+     * 100%.
+     *
+     * @param components
+     *            the components to set, not <code>null</code>
+     */
+    public void addAndExpand(Component... components) {
+        add(components);
+        setHeightFull();
+        expand(components);
+    }
 }

--- a/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/LayoutDefaultsTest.java
+++ b/vaadin-ordered-layout-flow/src/test/java/com/vaadin/flow/component/orderedlayout/tests/LayoutDefaultsTest.java
@@ -1,11 +1,14 @@
 package com.vaadin.flow.component.orderedlayout.tests;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import java.util.stream.Stream;
 
 public class LayoutDefaultsTest {
 
@@ -42,5 +45,24 @@ public class LayoutDefaultsTest {
 
         VerticalLayout verticalLayout = new VerticalLayout();
         verticalLayout.addClickListener(event -> {});
+    }
+
+    @Test
+    public void expandable_Layout() {
+        HorizontalLayout horizontalLayout = new HorizontalLayout();
+        horizontalLayout.addAndExpand(new Label("Foo"), new Label("bar"));
+        testExpandableComponent(horizontalLayout.getWidth(), horizontalLayout.getChildren());
+
+        VerticalLayout verticalLayout = new VerticalLayout();
+        verticalLayout.addAndExpand(new Label("Foo"), new Label("bar"));
+        testExpandableComponent(verticalLayout.getHeight(), verticalLayout.getChildren());
+    }
+
+    private void testExpandableComponent(String size, Stream<Component> components) {
+        Assert.assertEquals(size, "100%");
+
+        components.forEach(component ->
+                Assert.assertEquals(component.getElement().getStyle().get("flex-grow"), "1.0")
+        );
     }
 }


### PR DESCRIPTION
Fixes #86 

Implement `addAndExpand(Component... components)` to `HorizontalLayout` and `VerticalLayout`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-ordered-layout-flow/90)
<!-- Reviewable:end -->
